### PR TITLE
Add detail to README.md and fix variables in example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,23 @@
 ### govent - cli and library for sending events to the graphite events api
 
+#### Installation
+
 ```bash
-GRAPHITE_URL=https://example.com/events/ GRAPHITE_PASSWORD=foo GRAPHITE_USERNAME=bar govent --tag go.write.me.an.event.build --what what.aint.no.country "my data is fo realz"
+$ go get github.com/MediaMath/govent
+```
+
+#### Usage
+
+```bash
+$ export GRAPHITE_URL=https://example.com/events/
+$ export GRAPHITE_USERNAME=foo
+$ export GRAPHITE_PASSWORD=bar
+$ govent --tag go.write.me.an.event.build --what what.aint.no.country "my data is fo realz"
 ```
 
 ```go
+import "github.com/MediaMath/govent/graphite"
+
 g := graphite.New("foo", "bar", "https://example.com/events/")
 g.Publish(graphite.NewEvent("what.aint.no.country", "my data is fo realz", "go.write.me.an.event.build"))
 ```


### PR DESCRIPTION
- Add installation instruction for clarity (simple but helpful).
- Split out envvars for clarity
  - This has the added benefit of exposing a doc flaw: username and password are switched in the bash example
- Add import path to Go example
